### PR TITLE
Copying all attributes in FormSerializerOptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,4 @@ install:
 # command to run tests, e.g. python setup.py test
 script: make check
 
-sudo: required
-
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,6 @@ install:
 # command to run tests, e.g. python setup.py test
 script: make check
 
+sudo: required
+
 after_success: coveralls

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -120,5 +120,5 @@ Some fields:
 and mixins:
 
 * :obj:`EmptyStringFieldMixin <drf_braces.fields.mixins.EmptyStringFieldMixin>`
-* :obj:`AllowBlankFieldMixin <drf_braces.fields.mixins.AllowBlankFieldMixin>`
+* :obj:`AllowBlankNullFieldMixin <drf_braces.fields.mixins.AllowBlankNullFieldMixin>`
 * :obj:`ValueAsTextFieldMixin <drf_braces.fields.mixins.ValueAsTextFieldMixin>`

--- a/drf_braces/fields/_fields.py
+++ b/drf_braces/fields/_fields.py
@@ -5,32 +5,45 @@ from rest_framework import fields
 from rest_framework.fields import *  # noqa
 from rest_framework.fields import _UnvalidatedField  # noqa
 
-from .mixins import AllowBlankFieldMixin, EmptyStringFieldMixin
+from .mixins import AllowBlankNullFieldMixin, EmptyStringFieldMixin
 
 
-EMPTY_STRING_FIELDS = [
-    fields.DecimalField,
-    fields.IntegerField,
-    fields.DateTimeField,
-    fields.DateField,
-    fields.TimeField,
+FIELDS = [
+    'BooleanField',
+    'CharField',
+    'ChoiceField',
+    'DateField',
+    'DateTimeField',
+    'DecimalField',
+    'DurationField',
+    'EmailField',
+    'FileField',
+    'FloatField',
+    'HiddenField',
+    'ImageField',
+    'IntegerField',
+    'IPAddressField',
+    'MultipleChoiceField',
+    'NullBooleanField',
+    'RegexField',
+    'SlugField',
+    'TimeField',
+    'URLField',
+    'UUIDField',
 ]
 
-ALLOW_BLANK_FIELDS = [
-    fields.CharField,
-    fields.RegexField,
-]
 
-
-def get_updated_fields(fields, base_class):
+def get_updated_fields(fields, base_classes):
+    fields = [globals()[i] for i in fields]
     return {
-        field.__name__: type(field.__name__, (base_class, field), {})
+        field.__name__: type(field.__name__, base_classes + (field,), {})
         for field in fields
     }
 
 
-locals().update(get_updated_fields(EMPTY_STRING_FIELDS, EmptyStringFieldMixin))
-locals().update(get_updated_fields(ALLOW_BLANK_FIELDS, AllowBlankFieldMixin))
+locals().update(
+    get_updated_fields(FIELDS, (EmptyStringFieldMixin, AllowBlankNullFieldMixin))
+)
 
 __all__ = [name for name, value in locals().items()
            if inspect.isclass(value) and issubclass(value, fields.Field)]

--- a/drf_braces/fields/custom.py
+++ b/drf_braces/fields/custom.py
@@ -6,7 +6,7 @@ import six
 from django.utils.translation import gettext as _
 
 from . import _fields as fields
-from .mixins import EmptyStringFieldMixin, ValueAsTextFieldMixin
+from .mixins import ValueAsTextFieldMixin
 
 
 class UnvalidatedField(fields._UnvalidatedField):
@@ -39,7 +39,7 @@ class UTCDateTimeField(fields.DateTimeField):
         super(UTCDateTimeField, self).__init__(*args, **kwargs)
 
 
-class NonValidatingChoiceField(EmptyStringFieldMixin, fields.ChoiceField):
+class NonValidatingChoiceField(fields.ChoiceField):
     """
     ChoiceField subclass that skips the validation of "choices".
     It does apply 'required' validation, and any other validation

--- a/drf_braces/fields/mixins.py
+++ b/drf_braces/fields/mixins.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, unicode_literals
 
 import six
-from rest_framework.fields import empty
+from rest_framework.fields import CharField, empty
 
 
 class EmptyStringFieldMixin(object):
@@ -20,12 +20,20 @@ class EmptyStringFieldMixin(object):
         return super(EmptyStringFieldMixin, self).to_representation(value)
 
 
-class AllowBlankFieldMixin(object):
+class AllowBlankNullFieldMixin(object):
     def __init__(self, *args, **kwargs):
-        if not kwargs.get('required', True):
-            kwargs.setdefault('allow_blank', True)
-            kwargs.setdefault('allow_null', True)
-        super(AllowBlankFieldMixin, self).__init__(*args, **kwargs)
+        super(AllowBlankNullFieldMixin, self).__init__(*args, **kwargs)
+
+        # some DRF fields explicitly do not allow some kwargs
+        # therefore we adjust the field attributes directly
+        if not self.required:
+            if all([isinstance(self, CharField),
+                    hasattr(self, 'allow_blank'),
+                    'allow_blank' not in kwargs]):
+                self.allow_blank = True
+            if all([hasattr(self, 'allow_null'),
+                    'allow_null' not in kwargs]):
+                self.allow_null = True
 
 
 class ValueAsTextFieldMixin(object):

--- a/drf_braces/serializers/form_serializer.py
+++ b/drf_braces/serializers/form_serializer.py
@@ -100,6 +100,12 @@ class FormSerializerOptions(object):
                 'what is an expected behavior'.format(self.failure_mode)
             )
 
+        # copy all other custom keys
+        for k, v in vars(meta).items():
+            if hasattr(self, k):
+                continue
+            setattr(self, k, v)
+
 
 class FormSerializerMeta(serializers.SerializerMetaclass):
     def __new__(cls, name, bases, attrs):

--- a/drf_braces/tests/fields/test_fields.py
+++ b/drf_braces/tests/fields/test_fields.py
@@ -1,33 +1,13 @@
 from __future__ import print_function, unicode_literals
 import unittest
 
-from drf_braces.fields._fields import (
-    CharField,
-    DateField,
-    DateTimeField,
-    DecimalField,
-    IntegerField,
-    RegexField,
-    TimeField,
-)
-from drf_braces.fields.mixins import AllowBlankFieldMixin, EmptyStringFieldMixin
+from drf_braces.fields import _fields
+from drf_braces.fields.mixins import AllowBlankNullFieldMixin, EmptyStringFieldMixin
 
 
 class TestFields(unittest.TestCase):
     def test_subclasses(self):
-        fields = [
-            DecimalField,
-            IntegerField,
-            DateTimeField,
-            DateField,
-            TimeField,
-        ]
-        for f in fields:
+        for f in _fields.FIELDS:
+            f = getattr(_fields, f)
             self.assertTrue(issubclass(f, EmptyStringFieldMixin))
-
-        fields = [
-            CharField,
-            RegexField,
-        ]
-        for f in fields:
-            self.assertTrue(issubclass(f, AllowBlankFieldMixin))
+            self.assertTrue(issubclass(f, AllowBlankNullFieldMixin))

--- a/drf_braces/tests/fields/test_mixins.py
+++ b/drf_braces/tests/fields/test_mixins.py
@@ -5,7 +5,7 @@ import mock
 from rest_framework import fields
 
 from drf_braces.fields.mixins import (
-    AllowBlankFieldMixin,
+    AllowBlankNullFieldMixin,
     EmptyStringFieldMixin,
     ValueAsTextFieldMixin,
 )
@@ -57,7 +57,7 @@ class TestAllowBlankFieldMixin(unittest.TestCase):
     def setUp(self):
         super(TestAllowBlankFieldMixin, self).setUp()
 
-        class Field(AllowBlankFieldMixin, fields.CharField):
+        class Field(AllowBlankNullFieldMixin, fields.CharField):
             pass
 
         self.field_class = Field

--- a/drf_braces/tests/serializers/test_form_serialzier.py
+++ b/drf_braces/tests/serializers/test_form_serialzier.py
@@ -96,14 +96,15 @@ class TestUtils(unittest.TestCase):
 
 class TestFormSerializerOptions(unittest.TestCase):
     def test_init(self):
-        meta = mock.Mock(failure_mode='fail')
+        meta = mock.Mock(failure_mode='fail', foo='bar')
 
         options = FormSerializerOptions(meta, 'foo')
 
         self.assertEqual(options.form, meta.form)
         self.assertEqual(options.failure_mode, 'fail')
         self.assertEqual(options.minimum_required, meta.minimum_required)
-        self.assertEqual(options.field_mapping, options.field_mapping)
+        self.assertEqual(options.field_mapping, meta.field_mapping)
+        self.assertEqual(options.foo, meta.foo)
 
     def test_init_invalid(self):
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
also using `AllowBlankNullFieldMixin` and `EmptyStringFieldMixin` for all overwritten DRF fields