### PR TITLE
Testing the utils

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = *tests*

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ docs/_build
 
 # IDEs
 /.idea
+*.ropeproject
+*.swp

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 ~~~~~~~~~~~~
 
 * Khaled Porlin - https://github.com/porlin72
+* Agam Dua - https://github.com/agamdua

--- a/drf_braces/tests/test_utils.py
+++ b/drf_braces/tests/test_utils.py
@@ -1,0 +1,50 @@
+from __future__ import print_function, unicode_literals
+
+import unittest
+
+from drf_braces.utils import (
+    get_class_name_with_new_suffix,
+    get_attr_from_base_classes,
+)
+from rest_framework import fields
+
+
+class TestUtils(unittest.TestCase):
+    def test_get_class_name_with_new_suffix(self):
+        new_name = get_class_name_with_new_suffix(
+            klass=fields.IntegerField,
+            existing_suffix='Field',
+            new_suffix='StrawberryFields'
+        )
+        self.assertEqual(new_name, 'IntegerStrawberryFields')
+
+        new_name = get_class_name_with_new_suffix(
+            klass=fields.IntegerField,
+            existing_suffix='straws',
+            new_suffix='Blueberries'
+        )
+        self.assertEqual(new_name, 'IntegerFieldBlueberries')
+
+    def test_get_attr_from_base_classes(self):
+        Parent = type(str('Parent'), (), {'fields': 'pancakes'})
+
+        self.assertEqual(
+            get_attr_from_base_classes((Parent,), [], 'fields'), 'pancakes'
+        )
+
+        self.assertEqual(
+            get_attr_from_base_classes(
+                (Parent,), {'fields': 'mushrooms'}, 'fields'
+            ),
+            'mushrooms'
+        )
+
+        self.assertEqual(
+            get_attr_from_base_classes((Parent,), [], '', default='maple_syrup'),
+            'maple_syrup'
+        )
+
+        with self.assertRaises(AttributeError):
+            get_attr_from_base_classes(
+                (Parent,), {'fields': 'mushrooms'}, 'catchmeifyoucan'
+            )

--- a/drf_braces/utils.py
+++ b/drf_braces/utils.py
@@ -117,6 +117,17 @@ def initialize_class_using_reference_object(reference_object, klass, **kwargs):
 
 
 def get_class_name_with_new_suffix(klass, existing_suffix, new_suffix):
+    """
+    Generates new name by replacing the existing suffix with a new one.
+
+    Args:
+        klass (type): original class from which new name is generated
+        existing_suffix (str): the suffix which needs to remain where it is
+        new_suffix (str): the new suffix desired
+
+    Returns:
+        new_name (str): the name with the new suffix
+    """
     class_name = klass.__name__
 
     if existing_suffix in class_name:
@@ -130,6 +141,23 @@ def get_class_name_with_new_suffix(klass, existing_suffix, new_suffix):
 
 
 def get_attr_from_base_classes(bases, attrs, attr, **kwargs):
+    """
+    The base class attributes are retrieved if they are not already
+    present on the object.
+
+    Args:
+        bases (tuple, list): The base classes for a class
+        attrs (dict): The attributes of the class
+        attr (str): Specific attribute being looked for
+
+    Returns:
+        attribute value (str) or a default which is expected.
+
+    Raises:
+        AttributeError: When the attribute is not present anywhere in the
+            call chain hierarchy specified through bases and the attributes
+            of the class itself
+    """
     if attr in attrs:
         return attrs[attr]
 

--- a/drf_braces/utils.py
+++ b/drf_braces/utils.py
@@ -125,6 +125,10 @@ def get_class_name_with_new_suffix(klass, existing_suffix, new_suffix):
         existing_suffix (str): the suffix which needs to remain where it is
         new_suffix (str): the new suffix desired
 
+    Example:
+        >>> get_class_name_with_new_suffix(FooForm, 'Form', 'NewForm')
+        'FooNewForm'
+
     Returns:
         new_name (str): the name with the new suffix
     """
@@ -140,18 +144,21 @@ def get_class_name_with_new_suffix(klass, existing_suffix, new_suffix):
     return new_name
 
 
-def get_attr_from_base_classes(bases, attrs, attr, **kwargs):
+def get_attr_from_base_classes(bases, attrs, attr, default=None):
     """
-    The base class attributes are retrieved if they are not already
+    The attribute is retrieved from the base classes if they are not already
     present on the object.
 
     Args:
-        bases (tuple, list): The base classes for a class
-        attrs (dict): The attributes of the class
-        attr (str): Specific attribute being looked for
+        bases (tuple, list): The base classes for a class.
+        attrs (dict): The attributes of the class.
+        attr (str): Specific attribute being looked for.
+        default (any): Whatever default value is expected if the
+            attr is not found.
 
     Returns:
-        attribute value (str) or a default which is expected.
+        attribute value as found in base classes or a default when attribute
+        is not found and default is provided.
 
     Raises:
         AttributeError: When the attribute is not present anywhere in the
@@ -167,8 +174,8 @@ def get_attr_from_base_classes(bases, attrs, attr, **kwargs):
         except AttributeError:
             continue
 
-    if 'default' in kwargs:
-        return kwargs['default']
+    if default:
+        return default
 
     raise AttributeError(
         'None of the bases have {} attribute'


### PR DESCRIPTION
From commit messages:

```
Added: tests and docstrings for utils
Two utils methods were lacking coverage:
* `get_attr_from_base_classes`
* `get_class_name_with_new_suffix`

Added a `.coveragerc` so that coverage would not be tracking coverage of
actual tests code.

Docstrings were added for future reference.
```
```
Updated: gitignore for vim files
```
```
As part of  a review:

* get_attr_from_base_classes used kwargs to get the `default`. Now
`default` is an explicit kwarg, updated docstring and code to reflect
this
* updated docstring for `get_class_name_with_new_suffix` with an example
```