### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Collection of utilities for working with DRF. Name inspired by `django-braces <h
 
 * Free software: MIT license
 * GitHub: https://github.com/dealertrack/django-rest-framework-braces
-* Documentation: https://django-rest-framework-braces.readthedocs.org.
+* Documentation: https://django-rest-framework-braces.readthedocs.io.
 
 Installing
 ----------
@@ -34,7 +34,7 @@ For example::
             serializer = self.get_serializer(serializer_class=MySerializer)
             ...
 
-For full list of available utilities, please refer to the `documentation <https://django-rest-framework-braces.readthedocs.org>`_.
+For full list of available utilities, please refer to the `documentation <https://django-rest-framework-braces.readthedocs.io>`_.
 
 Testing
 -------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.